### PR TITLE
docs: improve README and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,5 +41,5 @@ Secrets (`GOOGLE_CREDENTIALS`, etc.) live in GitHub Actions — never hard-code 
 ## Things to leave alone unless asked
 
 - The Artifact Registry coordinates and Jib `to.image` in `build.gradle`.
-- The OTLP endpoint default in `application.yml` (`http://localhost:4317`) — it's intentional for local dev.
+- The OTLP endpoint default in `application.yml` (`http://localhost:4317`) — keep this local-dev/default endpoint as configured, but do not assume it means OTLP span exporting is wired by default.
 - Port `8001` — referenced from the container config and external callers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+Guidance for AI agents (e.g. Claude Code) working in this repository. Read [README.md](README.md) first for the user-facing overview, API, and run instructions; this file only covers things that aren't obvious from the README or the code.
+
+## Layout
+
+All Java sources live under `src/main/java/org/agencyapi/x509/inspector/`:
+
+| Path | Purpose |
+|------|---------|
+| `CertificateInspector.java` | Spring Boot entry point. |
+| `CertificateInspectorController.java` | REST controller. Owns the `inspect` span and exception → 400 mapping. |
+| `CertificateInspectorReply.java` | Response record + nested `CertificateInfo` projection of `X509Certificate`. |
+| `CertificateFetcher.java` / `CertificateUtils.java` / `IpUtils.java` | Certificate retrieval and helpers. |
+| `OpenTelemetryConfig.java` | Tracing wiring. |
+| `validators/` | Jakarta `ConstraintValidator` implementations (e.g. `@Domain`). |
+| `src/main/resources/application.yml` | Port `8001`, OTLP endpoint, log pattern with `traceId`/`spanId`. |
+
+There is no `src/test/` yet — when adding tests, use JUnit 5 (already on the classpath via `spring-boot-starter-test`).
+
+## Coding conventions
+
+- Java 25; prefer `var`, records, sealed types, pattern matching where it improves clarity.
+- Spring constructor injection only — no field `@Autowired`.
+- Input validation uses Jakarta constraints; put new annotations in the `validators` package and surface violations via the existing `ConstraintViolationException` handler in the controller.
+- Keep the `inspect` span (and any new spans) — observability is a hard requirement, not decoration.
+- Don't hand-edit dependency versions that Dependabot manages (Spring Boot, Jib, dnsjava); let the bot raise PRs.
+
+## CI / GitHub Actions
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `ci.yml` | Push / PR | Build and test |
+| `publish.yml` | Push to `main` | Build and push container image |
+| `release.yml` | Tag | Cut a release |
+| `dependency-review.yml` | PR | Check for vulnerable dependencies |
+| `dependency-submission.yml` | Push | Submit dependency graph to GitHub |
+
+Secrets (`GOOGLE_CREDENTIALS`, etc.) live in GitHub Actions — never hard-code or echo them.
+
+## Things to leave alone unless asked
+
+- The Artifact Registry coordinates and Jib `to.image` in `build.gradle`.
+- The OTLP endpoint default in `application.yml` (`http://localhost:4317`) — it's intentional for local dev.
+- Port `8001` — referenced from the container config and external callers.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # https-certificate-inspector
-A simple service that fetches details of a certificate used by an HTTPS service and captures key facts
+
+A small Spring Boot service that fetches the X.509 certificate chain presented by an HTTPS endpoint and returns key facts about each certificate as JSON.
+
+## Requirements
+
+- Java 25 (Adoptium). The Gradle toolchain will download it automatically if it's not already available.
+
+## Run locally
+
+```bash
+./gradlew bootRun       # starts the service on port 8001
+./gradlew build         # compile + tests
+./gradlew test          # tests only
+```
+
+## API
+
+| Method | Path                | Description                                                                                |
+|--------|---------------------|--------------------------------------------------------------------------------------------|
+| GET    | `/inspect/{domain}` | Connects to `https://{domain}` and returns the certificate chain. `{domain}` is validated. |
+| GET    | `/health`           | Liveness probe; returns `OK`.                                                              |
+| GET    | `/actuator/**`      | Spring Boot Actuator endpoints.                                                            |
+
+### Example
+
+```bash
+curl http://localhost:8001/inspect/example.com
+```
+
+```json
+{
+  "domain": "example.com",
+  "certificates": [
+    {
+      "subject": "CN=example.com,...",
+      "issuer": "CN=...",
+      "serialNumber": "...",
+      "validFrom": "...",
+      "validUntil": "...",
+      "signatureAlgorithm": "SHA256withRSA",
+      "version": 3
+    }
+  ]
+}
+```
+
+Invalid domains return `400 Bad Request`.
+
+## Observability
+
+Tracing is enabled via Micrometer Tracing with the OpenTelemetry bridge. Spans are exported via OTLP to `http://localhost:4317` by default (see `src/main/resources/application.yml`). Trace and span IDs are included in every log line.
+
+## Container image
+
+The image is built with [Jib](https://github.com/GoogleContainerTools/jib) on top of `eclipse-temurin:25-noble` and published by CI to:
+
+```
+europe-docker.pkg.dev/agencyapi/containers/https-certificate-inspector
+```
+
+Publishing requires GCP credentials and is handled by the GitHub Actions pipeline; do not run `./gradlew jib` locally without explicit registry access.
+
+## License
+
+See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ curl http://localhost:8001/inspect/example.com
 }
 ```
 
-Invalid domains return `400 Bad Request`.
+Requests that fail domain validation return `400 Bad Request`.
 
 ## Observability
 
-Tracing is enabled via Micrometer Tracing with the OpenTelemetry bridge. Spans are exported via OTLP to `http://localhost:4317` by default (see `src/main/resources/application.yml`). Trace and span IDs are included in every log line.
+Tracing is enabled via Micrometer Tracing with the OpenTelemetry bridge. Trace and span IDs are included in every log line. This README does not guarantee that spans are exported via OTLP by default; verify the runtime OpenTelemetry exporter configuration before relying on remote span export.
 
 ## Container image
 


### PR DESCRIPTION
## Summary
- Expand README with requirements, run commands, API reference + example, observability note, and container image details.
- Add AGENTS.md with repo-specific guidance for AI agents (source layout, conventions, CI workflows), pointing to README for the basics to avoid duplication.

## Test plan
- [ ] Render README.md on GitHub and confirm formatting (tables, code blocks).
- [ ] Render AGENTS.md on GitHub and confirm formatting.
- [ ] Verify links between the two files resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)