### PR TITLE
feat: add conditional TLS and mTLS support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,24 @@ All Java sources live under `src/main/java/org/agencyapi/x509/inspector/`:
 | `CertificateFetcher.java` / `CertificateUtils.java` / `IpUtils.java` | Certificate retrieval and helpers. |
 | `OpenTelemetryConfig.java` | Tracing wiring. |
 | `validators/` | Jakarta `ConstraintValidator` implementations (e.g. `@Domain`). |
+| `config/ConditionalTlsEnvironmentPostProcessor.java` | Flips Spring's HTTPS/mTLS settings on at startup if TLS properties are supplied. |
+| `config/ServerCertificateExpiryMonitor.java` | Daemon that exits the app if any TLS cert is within 10 min of expiry. |
+| `config/TlsConfigurationProperties.java` | Package-private helper resolving `inspector.tls.*` from properties or env vars. |
 | `src/main/resources/application.yml` | Port `8001`, OTLP endpoint, log pattern with `traceId`/`spanId`. |
+| `src/main/resources/META-INF/spring.factories` | Registers `ConditionalTlsEnvironmentPostProcessor`. |
 
-There is no `src/test/` yet — when adding tests, use JUnit 5 (already on the classpath via `spring-boot-starter-test`).
+Tests live under `src/test/java/org/agencyapi/x509/inspector/` and use JUnit 5 + AssertJ (transitively from `spring-boot-starter-test`).
+
+## HTTP, HTTPS, and mTLS
+
+Plain HTTP when no TLS settings are present. Supplying both a server certificate and private key enables HTTPS; adding a client CA enables mTLS (`server.ssl.client-auth=need`). See README "HTTPS and mTLS" for the property/env table and examples.
+
+When changing this code, keep the following invariants:
+
+- The post-processor must throw `IllegalStateException` if `certificate` or `private-key` is missing while any TLS setting is present — partial TLS config is never silently ignored.
+- The Spring SSL bundle name is `inspector` (`spring.ssl.bundle.pem.inspector.*`); changing it requires updating tests and any external SSL bundle references.
+- `ServerCertificateExpiryMonitor` must call `System.exit` (via `SpringApplication.exit`) — graceful return defeats the container-restart-on-expiry contract.
+- Don't commit certificates, private keys, or CA material to the repository.
 
 ## Coding conventions
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,48 @@ curl http://localhost:8001/inspect/example.com
 
 Requests that fail domain validation return `400 Bad Request`.
 
+## HTTPS and mTLS
+
+By default the service listens on plain HTTP (port 8001). If a server certificate and private key are provided at startup, HTTPS is enabled. If a client CA is also provided, the app requires client certificates and verifies them against that CA.
+
+| Property | Environment aliases | Description |
+|----------|---------------------|-------------|
+| `inspector.tls.certificate` | `INSPECTOR_TLS_CERTIFICATE`, `INSPECTOR_TLS_CERT` | Server certificate path/resource |
+| `inspector.tls.private-key` | `INSPECTOR_TLS_PRIVATE_KEY`, `INSPECTOR_TLS_KEY` | Server private key path/resource |
+| `inspector.tls.client-ca` | `INSPECTOR_TLS_CLIENT_CA` | Client CA path/resource; enables mTLS |
+
+HTTPS:
+
+```bash
+INSPECTOR_TLS_CERT=/run/tls/server.crt \
+INSPECTOR_TLS_KEY=/run/tls/server.key \
+./gradlew bootRun
+```
+
+mTLS:
+
+```bash
+INSPECTOR_TLS_CERT=/run/tls/server.crt \
+INSPECTOR_TLS_KEY=/run/tls/server.key \
+INSPECTOR_TLS_CLIENT_CA=/run/tls/client-ca.crt \
+./gradlew bootRun
+```
+
+Docker can publish a different host port while the app still listens on container port `8001`:
+
+```bash
+docker run -p 8443:8001 \
+  -e INSPECTOR_TLS_CERT=/run/tls/server.crt \
+  -e INSPECTOR_TLS_KEY=/run/tls/server.key \
+  -e INSPECTOR_TLS_CLIENT_CA=/run/tls/client-ca.crt \
+  -v /host/tls:/run/tls:ro \
+  europe-docker.pkg.dev/agencyapi/containers/https-certificate-inspector
+```
+
+Absolute filesystem paths are converted to `file:` resource URLs automatically. Relative paths, `classpath:`, and explicit `file:` URLs are passed through to Spring Boot SSL bundles. TLS material is loaded at startup, so rotating any of these files on disk requires restarting the app/container.
+
+When TLS is configured, the app checks the server certificate, and the client CA when present, immediately and then every 5 minutes using a daemon scheduled executor named `inspector-cert-expiry-monitor`. If any checked certificate expires within 10 minutes of the check time, the process exits with a non-zero status so the container supervisor can restart it and pick up fresh TLS material.
+
 ## Observability
 
 Tracing is enabled via Micrometer Tracing with the OpenTelemetry bridge. Trace and span IDs are included in every log line. This README does not guarantee that spans are exported via OTLP by default; verify the runtime OpenTelemetry exporter configuration before relying on remote span export.

--- a/src/main/java/org/agencyapi/x509/inspector/config/ConditionalTlsEnvironmentPostProcessor.java
+++ b/src/main/java/org/agencyapi/x509/inspector/config/ConditionalTlsEnvironmentPostProcessor.java
@@ -1,0 +1,58 @@
+package org.agencyapi.x509.inspector.config;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Enables HTTPS only when a server certificate and private key are supplied.
+ */
+public class ConditionalTlsEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+    private static final String PROPERTY_SOURCE_NAME = "inspectorConditionalTls";
+    private static final String BUNDLE_NAME = "inspector";
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        var certificate = TlsConfigurationProperties.certificate(environment);
+        var privateKey = TlsConfigurationProperties.privateKey(environment);
+        var clientCa = TlsConfigurationProperties.clientCa(environment);
+
+        if (!StringUtils.hasText(certificate) && !StringUtils.hasText(privateKey) && !StringUtils.hasText(clientCa)) {
+            return;
+        }
+
+        if (!StringUtils.hasText(certificate) || !StringUtils.hasText(privateKey)) {
+            throw new IllegalStateException("""
+                    Both inspector.tls.certificate and inspector.tls.private-key must be provided to enable HTTPS/mTLS.
+                    Leave all TLS settings unset to run plain HTTP.""");
+        }
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("server.ssl.enabled", "true");
+        properties.put("server.ssl.bundle", BUNDLE_NAME);
+        properties.put("spring.ssl.bundle.pem." + BUNDLE_NAME + ".keystore.certificate",
+                TlsConfigurationProperties.normalizeResourceLocation(certificate));
+        properties.put("spring.ssl.bundle.pem." + BUNDLE_NAME + ".keystore.private-key",
+                TlsConfigurationProperties.normalizeResourceLocation(privateKey));
+
+        if (StringUtils.hasText(clientCa)) {
+            properties.put("spring.ssl.bundle.pem." + BUNDLE_NAME + ".truststore.certificate",
+                    TlsConfigurationProperties.normalizeResourceLocation(clientCa));
+            properties.put("server.ssl.client-auth", "need");
+        }
+
+        environment.getPropertySources().remove(PROPERTY_SOURCE_NAME);
+        environment.getPropertySources().addFirst(new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/src/main/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitor.java
+++ b/src/main/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitor.java
@@ -106,7 +106,7 @@ public class ServerCertificateExpiryMonitor implements ApplicationRunner, Dispos
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.debug("Skipping {} expiry check during shutdown.", description, e);
+            logger.debug("Skipping {} expiry check due to thread interruption.", description, e);
         } catch (Exception e) {
             if (Thread.currentThread().isInterrupted() || isShuttingDown()) {
                 logger.debug("Skipping {} expiry check during shutdown.", description, e);

--- a/src/main/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitor.java
+++ b/src/main/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitor.java
@@ -1,0 +1,144 @@
+package org.agencyapi.x509.inspector.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.InputStream;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class ServerCertificateExpiryMonitor implements ApplicationRunner, DisposableBean {
+    private static final Logger logger = LoggerFactory.getLogger(ServerCertificateExpiryMonitor.class);
+    private static final Duration EXPIRY_EXIT_WINDOW = Duration.ofMinutes(10);
+    private static final Duration CHECK_INTERVAL = Duration.ofMinutes(5);
+    private static final String THREAD_NAME = "inspector-cert-expiry-monitor";
+
+    private final Environment environment;
+    private final ResourceLoader resourceLoader;
+    private final ConfigurableApplicationContext applicationContext;
+    private final Clock clock;
+    private ScheduledExecutorService executorService;
+
+    @Autowired
+    public ServerCertificateExpiryMonitor(Environment environment,
+                                          ResourceLoader resourceLoader,
+                                          ConfigurableApplicationContext applicationContext) {
+        this(environment, resourceLoader, applicationContext, Clock.systemUTC());
+    }
+
+    ServerCertificateExpiryMonitor(Environment environment,
+                                   ResourceLoader resourceLoader,
+                                   ConfigurableApplicationContext applicationContext,
+                                   Clock clock) {
+        this.environment = environment;
+        this.resourceLoader = resourceLoader;
+        this.applicationContext = applicationContext;
+        this.clock = clock;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        var certificateLocation = TlsConfigurationProperties.certificate(environment);
+        var clientCaLocation = TlsConfigurationProperties.clientCa(environment);
+        if (!StringUtils.hasText(certificateLocation) && !StringUtils.hasText(clientCaLocation)) {
+            return;
+        }
+
+        executorService = Executors.newSingleThreadScheduledExecutor(certificateMonitorThreadFactory());
+        executorService.scheduleWithFixedDelay(
+                () -> checkCertificates(certificateLocation, clientCaLocation),
+                0,
+                CHECK_INTERVAL.toSeconds(),
+                TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void destroy() {
+        if (executorService != null) {
+            executorService.shutdownNow();
+        }
+    }
+
+    private void checkCertificates(String certificateLocation, String clientCaLocation) {
+        if (StringUtils.hasText(certificateLocation)) {
+            checkCertificate(certificateLocation, "server TLS certificate", true);
+        }
+        if (StringUtils.hasText(clientCaLocation)) {
+            checkCertificate(clientCaLocation, "client CA certificate", false);
+        }
+    }
+
+    private void checkCertificate(String certificateLocation, String description, boolean firstCertificateOnly) {
+        try {
+            for (var certificate : loadCertificates(certificateLocation, firstCertificateOnly)) {
+                var expiresAt = certificate.getNotAfter().toInstant();
+                var exitThreshold = clock.instant().plus(EXPIRY_EXIT_WINDOW);
+                if (!expiresAt.isAfter(exitThreshold)) {
+                    logger.error("{} expires at {}, within the {} minute exit window. Exiting.",
+                            description, expiresAt, EXPIRY_EXIT_WINDOW.toMinutes());
+                    exitApplication();
+                } else {
+                    logger.debug("{} expires at {}", description, expiresAt);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Unable to verify {} expiry. Exiting.", description, e);
+            exitApplication();
+        }
+    }
+
+    private List<X509Certificate> loadCertificates(String certificateLocation, boolean firstCertificateOnly) throws Exception {
+        var resourceLocation = TlsConfigurationProperties.normalizeResourceLocation(certificateLocation);
+        var resource = resourceLoader.getResource(resourceLocation);
+        try (InputStream inputStream = resource.getInputStream()) {
+            var certificateFactory = CertificateFactory.getInstance("X.509");
+            Collection<X509Certificate> certificates = certificateFactory.generateCertificates(inputStream)
+                    .stream()
+                    .filter(X509Certificate.class::isInstance)
+                    .map(X509Certificate.class::cast)
+                    .toList();
+            if (certificates.isEmpty()) {
+                throw new IllegalStateException("No X.509 certificate found in " + certificateLocation);
+            }
+
+            if (firstCertificateOnly) {
+                return List.of(certificates.iterator().next());
+            }
+
+            return new ArrayList<>(certificates);
+        }
+    }
+
+    private void exitApplication() {
+        var exitCode = SpringApplication.exit(applicationContext, () -> 1);
+        System.exit(exitCode);
+    }
+
+    static ThreadFactory certificateMonitorThreadFactory() {
+        return runnable -> {
+            var thread = new Thread(runnable, THREAD_NAME);
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+}

--- a/src/main/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitor.java
+++ b/src/main/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitor.java
@@ -80,6 +80,9 @@ public class ServerCertificateExpiryMonitor implements ApplicationRunner, Dispos
     }
 
     private void checkCertificates(String certificateLocation, String clientCaLocation) {
+        if (isShuttingDown()) {
+            return;
+        }
         if (StringUtils.hasText(certificateLocation)) {
             checkCertificate(certificateLocation, "server TLS certificate", true);
         }
@@ -88,7 +91,7 @@ public class ServerCertificateExpiryMonitor implements ApplicationRunner, Dispos
         }
     }
 
-    private void checkCertificate(String certificateLocation, String description, boolean firstCertificateOnly) {
+    void checkCertificate(String certificateLocation, String description, boolean firstCertificateOnly) {
         try {
             for (var certificate : loadCertificates(certificateLocation, firstCertificateOnly)) {
                 var expiresAt = certificate.getNotAfter().toInstant();
@@ -101,13 +104,20 @@ public class ServerCertificateExpiryMonitor implements ApplicationRunner, Dispos
                     logger.debug("{} expires at {}", description, expiresAt);
                 }
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug("Skipping {} expiry check during shutdown.", description, e);
         } catch (Exception e) {
+            if (Thread.currentThread().isInterrupted() || isShuttingDown()) {
+                logger.debug("Skipping {} expiry check during shutdown.", description, e);
+                return;
+            }
             logger.error("Unable to verify {} expiry. Exiting.", description, e);
             exitApplication();
         }
     }
 
-    private List<X509Certificate> loadCertificates(String certificateLocation, boolean firstCertificateOnly) throws Exception {
+    List<X509Certificate> loadCertificates(String certificateLocation, boolean firstCertificateOnly) throws Exception {
         var resourceLocation = TlsConfigurationProperties.normalizeResourceLocation(certificateLocation);
         var resource = resourceLoader.getResource(resourceLocation);
         try (InputStream inputStream = resource.getInputStream()) {
@@ -129,9 +139,13 @@ public class ServerCertificateExpiryMonitor implements ApplicationRunner, Dispos
         }
     }
 
-    private void exitApplication() {
+    void exitApplication() {
         var exitCode = SpringApplication.exit(applicationContext, () -> 1);
         System.exit(exitCode);
+    }
+
+    private boolean isShuttingDown() {
+        return executorService != null && executorService.isShutdown();
     }
 
     static ThreadFactory certificateMonitorThreadFactory() {

--- a/src/main/java/org/agencyapi/x509/inspector/config/TlsConfigurationProperties.java
+++ b/src/main/java/org/agencyapi/x509/inspector/config/TlsConfigurationProperties.java
@@ -41,9 +41,12 @@ final class TlsConfigurationProperties {
     }
 
     static String normalizeResourceLocation(String location) {
+        if (location.startsWith("http:")) {
+            throw new IllegalArgumentException("Plain HTTP TLS material locations are not supported: " + location);
+        }
+
         if (location.startsWith("classpath:")
                 || location.startsWith("file:")
-                || location.startsWith("http:")
                 || location.startsWith("https:")) {
             return location;
         }

--- a/src/main/java/org/agencyapi/x509/inspector/config/TlsConfigurationProperties.java
+++ b/src/main/java/org/agencyapi/x509/inspector/config/TlsConfigurationProperties.java
@@ -1,0 +1,58 @@
+package org.agencyapi.x509.inspector.config;
+
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+
+import java.nio.file.Path;
+
+final class TlsConfigurationProperties {
+    static final String CERTIFICATE_PROPERTY = "inspector.tls.certificate";
+    static final String CERTIFICATE_ENV = "INSPECTOR_TLS_CERTIFICATE";
+    static final String CERTIFICATE_SHORT_ENV = "INSPECTOR_TLS_CERT";
+    static final String PRIVATE_KEY_PROPERTY = "inspector.tls.private-key";
+    static final String PRIVATE_KEY_ENV = "INSPECTOR_TLS_PRIVATE_KEY";
+    static final String PRIVATE_KEY_SHORT_ENV = "INSPECTOR_TLS_KEY";
+    static final String CLIENT_CA_PROPERTY = "inspector.tls.client-ca";
+    static final String CLIENT_CA_ENV = "INSPECTOR_TLS_CLIENT_CA";
+
+    private TlsConfigurationProperties() {
+    }
+
+    static String certificate(Environment environment) {
+        return getFirstPresent(environment, CERTIFICATE_PROPERTY, CERTIFICATE_ENV, CERTIFICATE_SHORT_ENV);
+    }
+
+    static String privateKey(Environment environment) {
+        return getFirstPresent(environment, PRIVATE_KEY_PROPERTY, PRIVATE_KEY_ENV, PRIVATE_KEY_SHORT_ENV);
+    }
+
+    static String clientCa(Environment environment) {
+        return getFirstPresent(environment, CLIENT_CA_PROPERTY, CLIENT_CA_ENV);
+    }
+
+    static String getFirstPresent(Environment environment, String... names) {
+        for (var name : names) {
+            var value = environment.getProperty(name);
+            if (StringUtils.hasText(value)) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+
+    static String normalizeResourceLocation(String location) {
+        if (location.startsWith("classpath:")
+                || location.startsWith("file:")
+                || location.startsWith("http:")
+                || location.startsWith("https:")) {
+            return location;
+        }
+
+        var path = Path.of(location);
+        if (path.isAbsolute()) {
+            return path.toUri().toString();
+        }
+
+        return location;
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.EnvironmentPostProcessor=\
+org.agencyapi.x509.inspector.config.ConditionalTlsEnvironmentPostProcessor

--- a/src/test/java/org/agencyapi/x509/inspector/config/ConditionalTlsEnvironmentPostProcessorTest.java
+++ b/src/test/java/org/agencyapi/x509/inspector/config/ConditionalTlsEnvironmentPostProcessorTest.java
@@ -1,0 +1,84 @@
+package org.agencyapi.x509.inspector.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConditionalTlsEnvironmentPostProcessorTest {
+    private final ConditionalTlsEnvironmentPostProcessor postProcessor = new ConditionalTlsEnvironmentPostProcessor();
+
+    @Test
+    void leavesHttpEnabledWhenTlsCertificateAndKeyAreMissing() {
+        var environment = new MockEnvironment();
+
+        postProcessor.postProcessEnvironment(environment, new SpringApplication());
+
+        assertThat(environment.getProperty("server.ssl.enabled")).isNull();
+        assertThat(environment.getProperty("server.ssl.client-auth")).isNull();
+    }
+
+    @Test
+    void enablesHttpsWhenCertificateAndPrivateKeyAreProvided() {
+        var environment = new MockEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "inspector.tls.certificate", "/run/tls/server.crt",
+                "inspector.tls.private-key", "/run/tls/server.key"
+        )));
+
+        postProcessor.postProcessEnvironment(environment, new SpringApplication());
+
+        assertThat(environment.getProperty("server.ssl.enabled")).isEqualTo("true");
+        assertThat(environment.getProperty("server.ssl.bundle")).isEqualTo("inspector");
+        assertThat(environment.getProperty("spring.ssl.bundle.pem.inspector.keystore.certificate"))
+                .isEqualTo("file:///run/tls/server.crt");
+        assertThat(environment.getProperty("spring.ssl.bundle.pem.inspector.keystore.private-key"))
+                .isEqualTo("file:///run/tls/server.key");
+        assertThat(environment.getProperty("server.ssl.client-auth")).isNull();
+    }
+
+    @Test
+    void enablesMutualTlsWhenClientCaIsProvided() {
+        var environment = new MockEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "inspector.tls.certificate", "/run/tls/server.crt",
+                "inspector.tls.private-key", "/run/tls/server.key",
+                "inspector.tls.client-ca", "/run/tls/client-ca.crt"
+        )));
+
+        postProcessor.postProcessEnvironment(environment, new SpringApplication());
+
+        assertThat(environment.getProperty("spring.ssl.bundle.pem.inspector.truststore.certificate"))
+                .isEqualTo("file:///run/tls/client-ca.crt");
+        assertThat(environment.getProperty("server.ssl.client-auth")).isEqualTo("need");
+    }
+
+    @Test
+    void failsFastWhenTlsConfigurationIsIncomplete() {
+        var environment = new MockEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "inspector.tls.certificate", "/run/tls/server.crt"
+        )));
+
+        assertThatThrownBy(() -> postProcessor.postProcessEnvironment(environment, new SpringApplication()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Both inspector.tls.certificate and inspector.tls.private-key");
+    }
+
+    @Test
+    void failsFastWhenClientCaIsConfiguredWithoutServerTls() {
+        var environment = new MockEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "inspector.tls.client-ca", "/run/tls/client-ca.crt"
+        )));
+
+        assertThatThrownBy(() -> postProcessor.postProcessEnvironment(environment, new SpringApplication()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Both inspector.tls.certificate and inspector.tls.private-key");
+    }
+}

--- a/src/test/java/org/agencyapi/x509/inspector/config/ConditionalTlsEnvironmentPostProcessorTest.java
+++ b/src/test/java/org/agencyapi/x509/inspector/config/ConditionalTlsEnvironmentPostProcessorTest.java
@@ -81,4 +81,17 @@ class ConditionalTlsEnvironmentPostProcessorTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Both inspector.tls.certificate and inspector.tls.private-key");
     }
+
+    @Test
+    void rejectsPlainHttpTlsMaterialLocations() {
+        var environment = new MockEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "inspector.tls.certificate", "http://example.test/server.crt",
+                "inspector.tls.private-key", "/run/tls/server.key"
+        )));
+
+        assertThatThrownBy(() -> postProcessor.postProcessEnvironment(environment, new SpringApplication()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Plain HTTP TLS material locations are not supported");
+    }
 }

--- a/src/test/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitorTest.java
+++ b/src/test/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitorTest.java
@@ -1,6 +1,13 @@
 package org.agencyapi.x509.inspector.config;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,5 +20,55 @@ class ServerCertificateExpiryMonitorTest {
 
         assertThat(thread.getName()).isEqualTo("inspector-cert-expiry-monitor");
         assertThat(thread.isDaemon()).isTrue();
+    }
+
+    @Test
+    void doesNotExitWhenCertificateLoadingIsInterrupted() {
+        var monitor = new TestableServerCertificateExpiryMonitor(new InterruptedException("shutdown"));
+
+        Thread.currentThread().interrupt();
+        try {
+            monitor.checkCertificate("ignored", "server TLS certificate", true);
+
+            assertThat(monitor.exitCalled).isFalse();
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void doesNotExitWhenCertificateCheckFailsDuringShutdown() {
+        var monitor = new TestableServerCertificateExpiryMonitor(new IllegalStateException("boom"));
+        var executorService = Executors.newSingleThreadScheduledExecutor();
+        executorService.shutdownNow();
+        ReflectionTestUtils.setField(monitor, "executorService", executorService);
+        try {
+            monitor.checkCertificate("ignored", "server TLS certificate", true);
+
+            assertThat(monitor.exitCalled).isFalse();
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private static final class TestableServerCertificateExpiryMonitor extends ServerCertificateExpiryMonitor {
+        private final Exception failure;
+        private boolean exitCalled;
+
+        private TestableServerCertificateExpiryMonitor(Exception failure) {
+            super(null, new DefaultResourceLoader(), new StaticApplicationContext(), Clock.systemUTC());
+            this.failure = failure;
+        }
+
+        @Override
+        List<java.security.cert.X509Certificate> loadCertificates(String certificateLocation, boolean firstCertificateOnly) throws Exception {
+            throw failure;
+        }
+
+        @Override
+        void exitApplication() {
+            exitCalled = true;
+        }
     }
 }

--- a/src/test/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitorTest.java
+++ b/src/test/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitorTest.java
@@ -43,13 +43,10 @@ class ServerCertificateExpiryMonitorTest {
         var executorService = Executors.newSingleThreadScheduledExecutor();
         executorService.shutdownNow();
         ReflectionTestUtils.setField(monitor, "executorService", executorService);
-        try {
-            monitor.checkCertificate("ignored", "server TLS certificate", true);
 
-            assertThat(monitor.exitCalled).isFalse();
-        } finally {
-            executorService.shutdownNow();
-        }
+        monitor.checkCertificate("ignored", "server TLS certificate", true);
+
+        assertThat(monitor.exitCalled).isFalse();
     }
 
     private static final class TestableServerCertificateExpiryMonitor extends ServerCertificateExpiryMonitor {

--- a/src/test/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitorTest.java
+++ b/src/test/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitorTest.java
@@ -1,0 +1,17 @@
+package org.agencyapi.x509.inspector.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServerCertificateExpiryMonitorTest {
+    @Test
+    void certificateMonitorThreadFactoryCreatesNamedDaemonThread() {
+        var thread = ServerCertificateExpiryMonitor.certificateMonitorThreadFactory()
+                .newThread(() -> {
+                });
+
+        assertThat(thread.getName()).isEqualTo("inspector-cert-expiry-monitor");
+        assertThat(thread.isDaemon()).isTrue();
+    }
+}

--- a/src/test/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitorTest.java
+++ b/src/test/java/org/agencyapi/x509/inspector/config/ServerCertificateExpiryMonitorTest.java
@@ -5,6 +5,7 @@ import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.security.cert.X509Certificate;
 import java.time.Clock;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -59,7 +60,7 @@ class ServerCertificateExpiryMonitorTest {
         }
 
         @Override
-        List<java.security.cert.X509Certificate> loadCertificates(String certificateLocation, boolean firstCertificateOnly) throws Exception {
+        List<X509Certificate> loadCertificates(String certificateLocation, boolean firstCertificateOnly) throws Exception {
             throw failure;
         }
 


### PR DESCRIPTION
## Summary
- Start as plain HTTP by default; supplying `inspector.tls.certificate` + `inspector.tls.private-key` at startup enables HTTPS via a PEM SSL bundle. Adding `inspector.tls.client-ca` enables mTLS (`server.ssl.client-auth=need`). Partial TLS config fails fast.
- New `ServerCertificateExpiryMonitor` daemon loads the configured server certificate (and client CA when present) at startup and every 5 minutes; if any checked certificate is within 10 minutes of expiry, the process exits non-zero so the container supervisor can restart and pick up rotated material.
- README and AGENTS updated with property/env tables, run examples (HTTPS, mTLS, Docker), and invariants the new code relies on.

## Test plan
- [x] `./gradlew test` — all new and existing tests pass.
- [ ] Boot with no TLS env vars → service serves plain HTTP on `:8001`.
- [ ] Boot with `INSPECTOR_TLS_CERT` + `INSPECTOR_TLS_KEY` → service serves HTTPS; `curl -k https://localhost:8001/health` returns `OK`.
- [ ] Boot with all three TLS env vars → mTLS enforced; client without cert is rejected, client with CA-signed cert succeeds.
- [ ] Boot with only `INSPECTOR_TLS_CERT` → app fails fast with the expected error.
- [ ] Boot with a soon-to-expire cert → expiry monitor logs and the process exits non-zero within ~5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)